### PR TITLE
changing test in tests/payments.py to align with new payment-type route

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -10,28 +10,34 @@ class PaymentTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
 
     def test_create_payment_type(self):
         """
         Ensure we can add a payment type for a customer.
         """
         # Add product to order
-        url = "/paymenttypes"
+        url = "/payment-types"
         data = {
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
-            "create_date": datetime.date.today()
+            "create_date": datetime.date.today(),
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
Bug: Payment type info is incorrect
https://github.com/NSS-Day-Cohort-76/Bangazon-client-zydyuv/issues/24

Changes
views/paymenttype.py changed lines 37/38 changing the mismatched expiration_date and create_date
Requests / Responses
If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

Request

POST /products Creates a new product

POST /payment-types
{
"merchant_name": "Amex",
"account_number": "000000000000",
"expiration_date": "2023-12-12",
"create_date": "2020-12-12"
}


**Response**

HTTP/1.1 201 CREATED

```json
{
  "id": 5,
  "url": "http://localhost:8000/payment-types/5",
  "merchant_name": "Amex",
  "account_number": "000000000000",
  "expiration_date": "2020-12-12",
  "create_date": "2023-12-12"
}
Testing
Description of how to test code...

 Run migrations
 Run test suite
 Seed database
Related Issues
Fixes #85
Fixes #22