### PR TITLE
fixing some minor bugs with logging in and showing if a user has a st…

### DIFF
--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -10,3 +10,4 @@ from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
 from .store import StoreViewSet
+from .store import StoreSerializer

--- a/bangazonapi/views/customer.py
+++ b/bangazonapi/views/customer.py
@@ -3,17 +3,27 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
-from bangazonapi.models import Customer
+from bangazonapi.models import Customer, Store  # ✅ ADD THIS
+from bangazonapi.views.store import StoreSerializer
 
 
 class CustomerSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customers"""
+
+    store = serializers.SerializerMethodField()
+
+    def get_store(self, obj):
+        store = Store.objects.filter(owner=obj.user).first()
+        if store:
+            return StoreSerializer(store, context=self.context).data
+        return None
+
     class Meta:
         model = Customer
         url = serializers.HyperlinkedIdentityField(
-            view_name='customer', lookup_field='id'
+            view_name="customer", lookup_field="id"
         )
-        fields = ('id', 'url', 'user', 'phone_number', 'address')
+        fields = ("id", "url", "user", "phone_number", "address", "store")
         depth = 1
 
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer profiles"""
+
 import datetime
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
@@ -12,10 +13,13 @@ from bangazonapi.models import OrderProduct, Favorite
 from bangazonapi.models import Recommendation
 from .product import ProductSerializer
 from .order import OrderSerializer
+from bangazonapi.models import Store
+from bangazonapi.views.store import StoreSerializer
 
 
 class Profile(ViewSet):
     """Request handlers for user profile info in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def list(self, request):
@@ -82,16 +86,19 @@ class Profile(ViewSet):
         """
         try:
             current_user = Customer.objects.get(user=request.auth.user)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user
+            )
 
             serializer = ProfileSerializer(
-                current_user, many=False, context={'request': request})
+                current_user, many=False, context={"request": request}
+            )
 
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-    @action(methods=['get', 'post', 'delete'], detail=False)
+    @action(methods=["get", "post", "delete"], detail=False)
     def cart(self, request):
         """Shopping cart manipulation"""
 
@@ -112,13 +119,14 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message.
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -175,20 +183,23 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                    line_items, many=True, context={"request": request}
+                )
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
+                cart["order"] = OrderSerializer(
+                    open_order, many=False, context={"request": request}
+                ).data
                 cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response(cart["order"])
 
@@ -241,18 +252,18 @@ class Profile(ViewSet):
                 open_order.customer = current_user
                 open_order.save()
 
-        line_item = OrderProduct()
-        line_item.product = Product.objects.get(pk=request.data["product_id"])
-        line_item.order = open_order
-        line_item.save()
+            line_item = OrderProduct()
+            line_item.product = Product.objects.get(pk=request.data["product_id"])
+            line_item.order = open_order
+            line_item.save()
 
-        line_item_json = LineItemSerializer(
-            line_item, many=False, context={'request': request})
+            line_item_json = LineItemSerializer(
+                line_item, many=False, context={"request": request}
+            )
 
-        return Response(line_item_json.data)
+            return Response(line_item_json.data)
 
-
-    @action(methods=['get'], detail=False)
+    @action(methods=["get"], detail=False)
     def favoritesellers(self, request):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
@@ -304,7 +315,8 @@ class Profile(ViewSet):
         favorites = Favorite.objects.filter(customer=customer)
 
         serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
+            favorites, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
 
@@ -314,11 +326,12 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
 
 
@@ -328,51 +341,81 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'email')
+        fields = ("first_name", "last_name", "email")
         depth = 1
 
 
 class CustomerSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendation customers"""
+
     user = UserSerializer()
 
     class Meta:
         model = Customer
-        fields = ('id', 'user',)
+        fields = (
+            "id",
+            "user",
+        )
 
 
 class ProfileProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
     class Meta:
         model = Product
-        fields = ('id', 'name',)
+        fields = (
+            "id",
+            "name",
+        )
 
 
 class RecommenderSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendations"""
+
     customer = CustomerSerializer()
     product = ProfileProductSerializer()
 
     class Meta:
         model = Recommendation
-        fields = ('product', 'customer',)
+        fields = (
+            "product",
+            "customer",
+        )
 
 
 class ProfileSerializer(serializers.ModelSerializer):
     """JSON serializer for customer profile
 
+
     Arguments:
         serializers
     """
+
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
+    store = serializers.SerializerMethodField()
+
+    def get_store(self, obj):
+        store = Store.objects.filter(owner=obj.user).first()
+        if store:
+            return StoreSerializer(store, context=self.context).data
+        return None
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user', 'phone_number',
-                  'address', 'payment_types', 'recommends',)
+        fields = (
+            "id",
+            "url",
+            "user",
+            "phone_number",
+            "address",
+            "payment_types",
+            "recommends",
+            "store",
+        )
         depth = 1
 
 
@@ -385,7 +428,7 @@ class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'username')
+        fields = ("first_name", "last_name", "username")
         depth = 1
 
 
@@ -400,7 +443,11 @@ class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user',)
+        fields = (
+            "id",
+            "url",
+            "user",
+        )
         depth = 1
 
 
@@ -415,5 +462,5 @@ class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Favorite
-        fields = ('id', 'seller')
+        fields = ("id", "seller")
         depth = 2


### PR DESCRIPTION
# Bangazon API — Store Profile Fixes and Enhancements

## 🧾 Summary

This PR includes fixes and updates related to user profile functionality and store visibility, completing backend work for the following tickets:

- ✅ #10: Create Store
- ✅ #3: "My Store" View
- ✅ #16: Store List with Seller Info + Product Count

---

## 🔧 Changes Made

- Updated `/profile` view to include the user's store (if they have one) by expanding the profile serializer
- Ensured the `Store` model is correctly serialized and added to the profile response
- Fixed logic issues when logging in, where the backend wasn't returning the store for authenticated users
- Cleaned up merge conflict in `profile.py` during rebase with latest `develop`

---

## ✅ Testing

- [x] Login with a user who owns a store returns their store in the `/profile` response
- [x] Login with a user who does **not** own a store returns `"store": null`
- [x] API returns valid JSON and status codes for all `/profile` and `/profile/cart` endpoints
- [x] Recommends, favorites, and cart behavior unaffected by changes

---

## ⚠️ Notes

- This PR was rebased onto the latest `develop` before pushing — force-pushed after resolving conflicts in `profile.py`.
- Frontend logic depends on this new `store` field being present in the `/profile` response, so merge this before finalizing UI behavior.

