### PR TITLE
Fixing StoreViewSet to handle 404s better

### DIFF
--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -48,6 +48,16 @@ class StoreViewSet(viewsets.ViewSet):
         serializer = StoreSerializer(new_store, context={"request": request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    def retrieve(self, request, pk=None):
+        try:
+            store = Store.objects.get(pk=pk)
+            serializer = StoreSerializer(store, context={"request": request})
+            return Response(serializer.data)
+        except Store.DoesNotExist:
+            return Response(
+                {"message": "Store not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+
     @action(detail=False, methods=["get"], permission_classes=[IsAuthenticated])
     def my_store(self, request):
         """Returns current user's store with Selling and Sold product lists"""


### PR DESCRIPTION
# 🧩 Backend: Add `retrieve()` to StoreViewSet and Handle 404s

## 🧠 Description

This PR adds the `retrieve()` method to the `StoreViewSet`, enabling `/stores/<id>` routes to fetch individual store data. It also ensures a clean `404` JSON response is returned when a store is not found.

## 🔧 Changes

- Added `retrieve(self, request, pk=None)` to `StoreViewSet`
- Catches `Store.DoesNotExist` and returns `{ "message": "Store not found" }` with status `404`
- Removed unreachable serializer code from previous version
- No changes to existing endpoints (`list`, `create`, `my_store`)

## 🧪 How to Test

1. Run server: `python manage.py runserver`
2. Visit `GET /stores/1` – should return valid store JSON
3. Visit `GET /stores/999` – should return:
```json
{ "message": "Store not found" }
```
4. No 500 errors should appear

## ✅ Closes

Closes #<ticket-number-if-applicable>
