### PR TITLE
Fixed Product serializer to include category

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -22,7 +22,7 @@ class ProductSerializer(serializers.ModelSerializer):
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
                   'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                  'average_rating', 'can_be_rated', 'category')
         depth = 1
 
 


### PR DESCRIPTION
Small update to Product view to add "category" field to serializer. first 5 products under each category should now render properly on the home page when nothing is Filtered.